### PR TITLE
Bug fix: Readded non-blog pages to markdown pages query

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -9,8 +9,7 @@ exports.createPages = ({ actions, graphql }) => {
   return graphql(`
     {
       allMarkdownRemark(
-        sort: { order: DESC, fields: [frontmatter___date] },
-        filter: { frontmatter: { templateKey: { eq: "blog-post" } }}
+        sort: { order: DESC, fields: [frontmatter___date] }
       ) {
         edges {
           node {

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -17,10 +17,11 @@ const Navbar = () => (
         <Link className="navbar-item" to="/about">
           About
         </Link>
-        <a 
+        <a
           className="navbar-item"
           href="https://meetup.com/awsugblr/"
           target="_blank"
+          rel="noreferrer"
           >Meetup Page</a>
       </div>
       <div className="navbar-end">
@@ -28,6 +29,7 @@ const Navbar = () => (
           className="navbar-item"
           href="https://github.com/awsugblr/awsugblr"
           target="_blank"
+          rel="noreferrer"
         >
           <span className="icon">
             <img src={github} alt="Github" style={{ width: '150px' }} />

--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -1,12 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Link, navigate } from 'gatsby'
+import { Link } from 'gatsby'
 import Layout from '../components/Layout'
 
 export default class IndexPage extends React.Component {
   render() {
     const { pageContext } = this.props
-    const { group, index, first, last, pageCount } = pageContext
+    const { group, index, pageCount } = pageContext
 
     return (
       <Layout>


### PR DESCRIPTION
Due to PR #327, about page was ignored from the createPage function due to the added filter, leading to a 404. The query has been fixed. Also, unused variables have been removed.

@SathyaBhat Accidentally introduced this bug in the last PR that I made--should have tested it fully before commit. Anyway this fixes it. Enjoy! 👍  :)